### PR TITLE
Addressing modes

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -131,6 +131,11 @@ public:
 		return m_pc;
 	}
 
+    //this method is for indirect addressing and is pretty much only used for the JMP instruction
+    void setPc(uint16_t addr) {
+        m_pc = addr;
+    }
+
 	//calls cycle() on the clock to notify that 1 clock cycle of work has occurred
 	void cycle() {
 		m_clock.cycle();

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -148,7 +148,7 @@ args_t getArgs(cpu_t* cpu) {
      * Indexed Indirect X 
      */
     if constexpr(MODE == addressMode_t::INDIRECT_X) {
-        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + X;
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + cpu->getX();
         cpu->cycle();
         assert(cpu->getPc() + 1 < 256);
         uint16_t realAddr = cpu->read(addressToAccess);
@@ -161,7 +161,7 @@ args_t getArgs(cpu_t* cpu) {
      * Indexed Indirect Y 
      */
     if constexpr(MODE == addressMode_t::INDIRECT_X) {
-        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + Y;
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + cpu->getY();
         cpu->cycle();
         assert(cpu->getPc() + 1 < 256);
         uint16_t realAddr = cpu->read(addressToAccess);

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -136,8 +136,43 @@ args_t getArgs(cpu_t* cpu) {
     if constexpr(MODE == addressMode_t::ACCUMULATOR) {
         cpu->cycle();
     }
+    /*
+     * Immediate: instructions operate directly on a constant supplied as an operand (pc + 1)
+     */
+    if constexpr(MODE == addressMode_t::IMMEDIATE) {
+        cpu->cycle();
+        args.m_arg1 = cpu->read(cpu->getPc());
+        cpu->cycle();
+    }
+    /*
+     * Indexed Indirect X 
+     */
+    if constexpr(MODE == addressMode_t::INDIRECT_X) {
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + X;
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        uint16_t realAddr = cpu->read(addressToAccess);
+        realAddr = realAddr & (cpu->read(addressToAccess + 1) << 8);
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        args.m_arg1 = cpu->read(realAddr);    
+    }
+    /*
+     * Indexed Indirect Y 
+     */
+    if constexpr(MODE == addressMode_t::INDIRECT_X) {
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1) + Y;
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        uint16_t realAddr = cpu->read(addressToAccess);
+        realAddr = realAddr & (cpu->read(addressToAccess + 1) << 8);
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        args.m_arg1 = cpu->read(realAddr);    
+    }
 
-	//TODO write the rest of the cases
+    //TODO: Relative Case, This might be better off handled directly in the instruction implemenation? Its only used on conditional branches.
+
     return args;
 }
 

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -121,7 +121,20 @@ args_t getArgs(cpu_t* cpu) {
         assert(cpu->getPc() + 1 < 256);
         uint16_t jumpAddress = cpu->read(addressToAccess);
         jumpAddress = jumpAddress & (cpu->read(addressToAccess + 1) << 8);
+        cpu->cycle();
         cpu->setPc(jumpAddress);
+    }
+    /*
+     *  Implied: instructions that do not require access to operands stored in memory: basically just cycle the cpu (NOP: pc + 1)
+     */
+    if constexpr(MODE == addressMode_t::IMPLIED) {
+        cpu->cycle();
+    }
+    /*
+     * Accumumlator: instructions that operate directly on the contents of the accumulator: just cycle the cpu once (pc + 1)
+     */
+    if constexpr(MODE == addressMode_t::ACCUMULATOR) {
+        cpu->cycle();
     }
 
 	//TODO write the rest of the cases

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -70,17 +70,44 @@ args_t getArgs(cpu_t* cpu) {
         cpu->cycle();
     }
     /*
-     * Absolute: data to operate on is in 2 operands supplied, LSB first MEM[ MEM[ PC + 2 ] :: MEM[ PC + 1] ]
+     * Absolute: data to operate on is in 2 operands supplied, LSB first. MEM[ MEM[ PC + 2 ]::MEM[ PC + 1] ]
      */
     if constexpr(MODE == addressMode_t::ABSOLUTE) {
         uint16_t addressToAccess = cpu->read(cpu->getPc() + 1);
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
         addressToAccess = addressToAccess & (cpu->read(cpu->getPc() +1) << 8);
         cpu->cycle();
         assert(cpu->getPc() + 1 < 256);
         args.m_arg1 = cpu->read(addressToAccess);
         cpu->cycle();
     }
-
+    /*
+     * Absolute: data to operate on is in 2 operands supplied + X register, LSB first. MEM[ MEM[ PC + 2 ]::MEM[ PC + 1] + X]
+     */
+    if constexpr(MODE == addressMode_t::ABSOLUTE_X) {
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1);
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        addressToAccess = (addressToAccess & (cpu->read(cpu->getPc() + 1) << 8)) + cpu->getX();
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        args.m_arg1 = cpu->read(addressToAccess);
+        cpu->cycle();
+    }
+    /*
+     * Absolute: data to operate on is in 2 operands supplied + Y register, LSB first. MEM[ MEM[ PC + 2 ]::MEM[ PC + 1] + X]
+     */
+    if constexpr(MODE == addressMode_t::ABSOLUTE_X) {
+        uint16_t addressToAccess = cpu->read(cpu->getPc() + 1);
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        addressToAccess = (addressToAccess & (cpu->read(cpu->getPc() + 1) << 8)) + cpu->getY();
+        cpu->cycle();
+        assert(cpu->getPc() + 1 < 256);
+        args.m_arg1 = cpu->read(addressToAccess);
+        cpu->cycle();
+    }
 	//TODO write the rest of the cases
     return args;
 }


### PR DESCRIPTION
All addressing modes are implemented except for relative.

Because relative uses a conditional to determine the new PC, this may be better implemented in the instruction directly.